### PR TITLE
Season stats worst coach method.kk

### DIFF
--- a/lib/game_teams.rb
+++ b/lib/game_teams.rb
@@ -16,6 +16,7 @@ class GameTeam
                 :face_off_win_percentage,
                 :giveaways,
                 :takeaways
+  attr_accessor :season
   
   def initialize(stats)
     @game_id = stats[:game_id]
@@ -33,5 +34,6 @@ class GameTeam
     @face_off_win_percentage = stats[:face_off_win_percentage].to_i
     @giveaways = stats[:giveaways].to_i
     @takeaways = stats[:takeaways].to_i
+    @season = nil
   end
 end

--- a/lib/game_teams.rb
+++ b/lib/game_teams.rb
@@ -1,6 +1,8 @@
 require './lib/league_stats'
+require './lib/season_stats'
+
 class GameTeam
-    include LeagueStats
+    include LeagueStats, SeasonStats
     attr_reader :game_id,
                 :team_id,
                 :hoa,

--- a/lib/season_stats.rb
+++ b/lib/season_stats.rb
@@ -1,9 +1,28 @@
 module SeasonStats
-
-  def worst_coach(season)
-    @games.each do |game|
-
+  
+  def worst_coach(the_season)
+    season_game_teams = @game_teams.select{|game_team| game_team.season == the_season}
+    coach_losses = Hash.new(0)
+    coach_ties = Hash.new(0)
+    coach_games = Hash.new(0)
+    season_game_teams.each do |game|
+      coach = game.head_coach
+      if game.result == 'WIN'
+        coach_games[coach] += 1
+      elsif game.result == 'LOSS' 
+        coach_losses[coach] += 1
+        coach_games[coach] += 1
+      elsif game.result == 'TIE' 
+        coach_ties[coach] += 1
+        coach_games[coach] += 1
+      end
     end
+    win_percentage_by_coach = {}
+    coach_games.each do |coach, games|
+      wins = games - coach_losses[coach] - coach_ties[coach]
+      win_percentage_by_coach[coach] = (wins.to_f).fdiv(games.to_f)
+    end
+    win_percentage_by_coach.min_by{ |coach, win_percentage| win_percentage}[0]
   end
 
   def most_accurate_team(season)

--- a/lib/season_stats.rb
+++ b/lib/season_stats.rb
@@ -1,5 +1,11 @@
 module SeasonStats
 
+  def worst_coach(season)
+    @games.each do |game|
+
+    end
+  end
+
   def most_accurate_team(season)
     team_ratios = Hash.new { |hash, key| hash[key] = [0, 0] }
   
@@ -87,5 +93,12 @@ module SeasonStats
   def team_by_id(id)
     team = @teams.find{|team| team.team_id == id.to_s}
     team.team_name
+  end
+
+  def season_by_id(id)
+    seasonal_game = @games.find do |game|
+      game.game_id == id
+    end
+    seasonal_game.season 
   end
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -42,7 +42,7 @@ class StatTracker
   def instantiate_game_teams(locations)
     game_team_info = CSV.open(locations, headers: true, header_converters: :symbol)
     game_team_info.map do |row| 
-      @game_teams << GameTeam.new({
+      game_team = GameTeam.new({
         game_id: row[:game_id],
         team_id: row[:team_id],
         hoa: row[:hoa],
@@ -57,7 +57,10 @@ class StatTracker
         power_play_goals: row[:power_play_goals],
         face_off_win_percentage: row[:face_off_win_percentage],
         giveaways: row[:giveaways],
-        takeaways: row[:takeaways]})
+        takeaways: row[:takeaways]
+        })
+        game_team.season = assign_season(row[:game_id])
+        @game_teams << game_team
     end
   end
 
@@ -71,5 +74,11 @@ class StatTracker
         abbreviation: row[:abbreviation],
         link: row[:link]})
     end
+  end
+
+#helper
+  def assign_season(game_id) 
+    the_season = season_by_id(game_id)
+    @season = the_season
   end
 end

--- a/spec/game_teams_spec.rb
+++ b/spec/game_teams_spec.rb
@@ -44,5 +44,14 @@ RSpec.describe GameTeam do
       expect(@game_team.giveaways).to eq(17)
       expect(@game_team.takeaways).to eq(7)
     end
+
+    it 'begins without a season' do 
+      expect(@game_team.season).to be nil
+    end
+
+    it 'can be given a season' do 
+      @game_team.season = '20122013'
+      expect(@game_team.season)
+    end
   end
 end

--- a/spec/game_teams_spec.rb
+++ b/spec/game_teams_spec.rb
@@ -48,10 +48,5 @@ RSpec.describe GameTeam do
     it 'begins without a season' do 
       expect(@game_team.season).to be nil
     end
-
-    it 'can be given a season' do 
-      @game_team.season = '20122013'
-      expect(@game_team.season)
-    end
   end
 end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -17,25 +17,25 @@ RSpec.describe StatTracker do
   end
   
   describe '#initialize' do 
-    it 'exists' do 
+    xit 'exists' do 
       expect(@stat_tracker).to be_a(StatTracker)
     end
 
-    it 'has an array of games' do 
+    xit 'has an array of games' do 
       expect(@stat_tracker.games).to be_a Array
       expect(@stat_tracker.games[0]).to be_a Game
     end
     
-    it 'has an array of gameteams' do    
+    xit 'has an array of gameteams' do    
       expect(@stat_tracker.game_teams).to be_a Array
       expect(@stat_tracker.game_teams[0]).to be_a GameTeam
     end
 
-    it 'game_teams have seasons by assignment' do 
+    xit 'game_teams have seasons by assignment' do 
       expect(@stat_tracker.game_teams[0].season).to eq('20122013')
     end
 
-    it 'has an array of teams' do 
+    xit 'has an array of teams' do 
       expect(@stat_tracker.teams).to be_a Array
       expect(@stat_tracker.teams[0]).to be_a Team
     end
@@ -44,11 +44,11 @@ RSpec.describe StatTracker do
 #game class
 
   describe 'game averages' do 
-    it '#average_goals_per_game' do 
+    xit '#average_goals_per_game' do 
       expect(@stat_tracker.average_goals_per_game).to eq(4.22)
     end
 
-    it '#average_goals_by_season' do 
+    xit '#average_goals_by_season' do 
       expect(@stat_tracker.average_goals_by_season).to eq({
           "20122013"=>4.12,
           "20162017"=>4.23,
@@ -59,33 +59,33 @@ RSpec.describe StatTracker do
       })
     end
 
-    it 'can collect the sum of highest winning scores' do
+    xit 'can collect the sum of highest winning scores' do
       expect(@stat_tracker.highest_total_score).to eq(11)
     end
 
-    it 'can collect the sum of lowest winning scores' do
+    xit 'can collect the sum of lowest winning scores' do
       expect(@stat_tracker.lowest_total_score).to eq(0)
     end
   end
 
   describe 'percentage of wins' do 
-    it 'can calculate the percentage of home wins' do 
+    xit 'can calculate the percentage of home wins' do 
       expect(@stat_tracker.percentage_home_wins).to eq(0.44)
     end 
 
-    it 'can calculate the percentage of visitor wins' do 
+    xit 'can calculate the percentage of visitor wins' do 
       expect(@stat_tracker.percentage_visitor_wins).to eq(0.36)
     end
   end
 
   describe '#percentage_ties method' do
-    it 'shows the percentage of ties per season' do 
+    xit 'shows the percentage of ties per season' do 
       expect(@stat_tracker.percentage_ties).to eq(0.2)
     end
   end
 
   describe '#count_of_games_by_season method' do
-    it 'counts number of games played per season' do
+    xit 'counts number of games played per season' do
       hash = {"20122013"=>806, "20132014"=>1323, "20142015"=>1319, "20152016"=>1321, "20162017"=>1317, "20172018"=>1355}
       expect(@stat_tracker.count_of_games_by_season).to eq(hash)
     end
@@ -94,66 +94,74 @@ RSpec.describe StatTracker do
 #game_teams/league stats
 
   describe 'count of teams' do 
-    it 'can count the total number of teams in the data' do 
+    xit 'can count the total number of teams in the data' do 
       expect(@stat_tracker.count_of_teams).to eq(32)
     end
   end
 
   describe 'best offense' do 
-    it 'can return team with highest average goals per game' do 
+    xit 'can return team with highest average goals per game' do 
       expect(@stat_tracker.best_offense).to eq('Reign FC')
     end
   end
 
   describe 'worst offense' do 
-    it 'can return team with lowest average goals per game' do 
+    xit 'can return team with lowest average goals per game' do 
       expect(@stat_tracker.worst_offense).to eq('Utah Royals FC')
     end
   end
 
   describe 'highest scoring avg' do 
-    it 'can return name of team with highest avg score per game when they are away' do 
+    xit 'can return name of team with highest avg score per game when they are away' do 
       expect(@stat_tracker.highest_scoring_visitor).to eq('FC Dallas')
     end
   
-    it 'can return name of team with highest avg score per game when they are home' do 
+    xit 'can return name of team with highest avg score per game when they are home' do 
       expect(@stat_tracker.highest_scoring_home_team).to eq('Reign FC')
     end
   end
 
   describe 'lowest scoring avg' do 
-    it 'can return name of team with lowest score per game when they are away' do 
+    xit 'can return name of team with lowest score per game when they are away' do 
       expect(@stat_tracker.lowest_scoring_visitor).to eq('San Jose Earthquakes')
     end
 
-    it 'can return name of team with lowest score per game when they are home' do
+    xit 'can return name of team with lowest score per game when they are home' do
       expect(@stat_tracker.lowest_scoring_home_team).to eq('Utah Royals FC')
     end
   end
 
   describe 'most accurate team' do
-    it "#most_accurate_team" do
+    xit "#most_accurate_team" do
       expect(@stat_tracker.most_accurate_team("20132014")).to eq "Real Salt Lake"
       expect(@stat_tracker.most_accurate_team("20142015")).to eq "Toronto FC"
     end
   end
 
   describe 'least accurate team' do
-    it "#least_accurate_team" do
+    xit "#least_accurate_team" do
       expect(@stat_tracker.least_accurate_team("20132014")).to eq "New York City FC"
       expect(@stat_tracker.least_accurate_team("20142015")).to eq "Columbus Crew SC"
     end
   end
 
   describe '#fewest_tackles' do 
-    it 'can track the team with the least tackles per season' do 
+    xit 'can track the team with the least tackles per season' do 
       expect(@stat_tracker.fewest_tackles("20132014")).to eq "Atlanta United"
       expect(@stat_tracker.fewest_tackles("20142015")).to eq "Orlando City SC"
     end
   end
 
+  #season_stats
+
+  describe 'coach quality' do
+    it "#worst_coach" do
+      expect(@stat_tracker.worst_coach("20122013")).to eq ('Martin Raymond')
+    end
+  end
+
   describe 'helpers' do 
-    it '#total_goals' do 
+    xit '#total_goals' do 
       expect(@stat_tracker.total_goals(@test_games)).to eq(397)
     end
   end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe StatTracker do
       expect(@stat_tracker.game_teams).to be_a Array
       expect(@stat_tracker.game_teams[0]).to be_a GameTeam
     end
+
+    it 'game_teams have seasons by assignment' do 
+      expect(@stat_tracker.game_teams[0].season).to eq('20122013')
+    end
+
     it 'has an array of teams' do 
       expect(@stat_tracker.teams).to be_a Array
       expect(@stat_tracker.teams[0]).to be_a Team

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -17,25 +17,25 @@ RSpec.describe StatTracker do
   end
   
   describe '#initialize' do 
-    xit 'exists' do 
+    it 'exists' do 
       expect(@stat_tracker).to be_a(StatTracker)
     end
 
-    xit 'has an array of games' do 
+    it 'has an array of games' do 
       expect(@stat_tracker.games).to be_a Array
       expect(@stat_tracker.games[0]).to be_a Game
     end
     
-    xit 'has an array of gameteams' do    
+    it 'has an array of gameteams' do    
       expect(@stat_tracker.game_teams).to be_a Array
       expect(@stat_tracker.game_teams[0]).to be_a GameTeam
     end
 
-    xit 'game_teams have seasons by assignment' do 
+    it 'game_teams have seasons by assignment' do 
       expect(@stat_tracker.game_teams[0].season).to eq('20122013')
     end
 
-    xit 'has an array of teams' do 
+    it 'has an array of teams' do 
       expect(@stat_tracker.teams).to be_a Array
       expect(@stat_tracker.teams[0]).to be_a Team
     end
@@ -44,11 +44,11 @@ RSpec.describe StatTracker do
 #game class
 
   describe 'game averages' do 
-    xit '#average_goals_per_game' do 
+    it '#average_goals_per_game' do 
       expect(@stat_tracker.average_goals_per_game).to eq(4.22)
     end
 
-    xit '#average_goals_by_season' do 
+    it '#average_goals_by_season' do 
       expect(@stat_tracker.average_goals_by_season).to eq({
           "20122013"=>4.12,
           "20162017"=>4.23,
@@ -59,33 +59,33 @@ RSpec.describe StatTracker do
       })
     end
 
-    xit 'can collect the sum of highest winning scores' do
+    it 'can collect the sum of highest winning scores' do
       expect(@stat_tracker.highest_total_score).to eq(11)
     end
 
-    xit 'can collect the sum of lowest winning scores' do
+    it 'can collect the sum of lowest winning scores' do
       expect(@stat_tracker.lowest_total_score).to eq(0)
     end
   end
 
   describe 'percentage of wins' do 
-    xit 'can calculate the percentage of home wins' do 
+    it 'can calculate the percentage of home wins' do 
       expect(@stat_tracker.percentage_home_wins).to eq(0.44)
     end 
 
-    xit 'can calculate the percentage of visitor wins' do 
+    it 'can calculate the percentage of visitor wins' do 
       expect(@stat_tracker.percentage_visitor_wins).to eq(0.36)
     end
   end
 
   describe '#percentage_ties method' do
-    xit 'shows the percentage of ties per season' do 
+    it 'shows the percentage of ties per season' do 
       expect(@stat_tracker.percentage_ties).to eq(0.2)
     end
   end
 
   describe '#count_of_games_by_season method' do
-    xit 'counts number of games played per season' do
+    it 'counts number of games played per season' do
       hash = {"20122013"=>806, "20132014"=>1323, "20142015"=>1319, "20152016"=>1321, "20162017"=>1317, "20172018"=>1355}
       expect(@stat_tracker.count_of_games_by_season).to eq(hash)
     end
@@ -94,59 +94,59 @@ RSpec.describe StatTracker do
 #game_teams/league stats
 
   describe 'count of teams' do 
-    xit 'can count the total number of teams in the data' do 
+    it 'can count the total number of teams in the data' do 
       expect(@stat_tracker.count_of_teams).to eq(32)
     end
   end
 
   describe 'best offense' do 
-    xit 'can return team with highest average goals per game' do 
+    it 'can return team with highest average goals per game' do 
       expect(@stat_tracker.best_offense).to eq('Reign FC')
     end
   end
 
   describe 'worst offense' do 
-    xit 'can return team with lowest average goals per game' do 
+    it 'can return team with lowest average goals per game' do 
       expect(@stat_tracker.worst_offense).to eq('Utah Royals FC')
     end
   end
 
   describe 'highest scoring avg' do 
-    xit 'can return name of team with highest avg score per game when they are away' do 
+    it 'can return name of team with highest avg score per game when they are away' do 
       expect(@stat_tracker.highest_scoring_visitor).to eq('FC Dallas')
     end
   
-    xit 'can return name of team with highest avg score per game when they are home' do 
+    it 'can return name of team with highest avg score per game when they are home' do 
       expect(@stat_tracker.highest_scoring_home_team).to eq('Reign FC')
     end
   end
 
   describe 'lowest scoring avg' do 
-    xit 'can return name of team with lowest score per game when they are away' do 
+    it 'can return name of team with lowest score per game when they are away' do 
       expect(@stat_tracker.lowest_scoring_visitor).to eq('San Jose Earthquakes')
     end
 
-    xit 'can return name of team with lowest score per game when they are home' do
+    it 'can return name of team with lowest score per game when they are home' do
       expect(@stat_tracker.lowest_scoring_home_team).to eq('Utah Royals FC')
     end
   end
 
   describe 'most accurate team' do
-    xit "#most_accurate_team" do
+    it "#most_accurate_team" do
       expect(@stat_tracker.most_accurate_team("20132014")).to eq "Real Salt Lake"
       expect(@stat_tracker.most_accurate_team("20142015")).to eq "Toronto FC"
     end
   end
 
   describe 'least accurate team' do
-    xit "#least_accurate_team" do
+    it "#least_accurate_team" do
       expect(@stat_tracker.least_accurate_team("20132014")).to eq "New York City FC"
       expect(@stat_tracker.least_accurate_team("20142015")).to eq "Columbus Crew SC"
     end
   end
 
   describe '#fewest_tackles' do 
-    xit 'can track the team with the least tackles per season' do 
+    it 'can track the team with the least tackles per season' do 
       expect(@stat_tracker.fewest_tackles("20132014")).to eq "Atlanta United"
       expect(@stat_tracker.fewest_tackles("20142015")).to eq "Orlando City SC"
     end
@@ -161,7 +161,7 @@ RSpec.describe StatTracker do
   end
 
   describe 'helpers' do 
-    xit '#total_goals' do 
+    it '#total_goals' do 
       expect(@stat_tracker.total_goals(@test_games)).to eq(397)
     end
   end


### PR DESCRIPTION
This pull request adds a season attribute to game_teams and tests it. 
It creates a helper method to assign seasons to game_teams by game_id matching. 
It adds a line of code to assign seasons to game_teams during instantiation by stat_tracker. 
This is all set-up to give access to seasons in the #worst_coach(season) method 
This pr ultimately writes the #worst_coach method 